### PR TITLE
build(lint): use pure prettier for formatting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,7 @@ extends:
   - airbnb-typescript
   - plugin:jest/recommended
   - plugin:jest/style
-  - plugin:prettier/recommended
+  - prettier
 plugins:
   - react-hooks
   - unicorn

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,18 +5,8 @@
     "source.fixAll.stylelint": true
   },
   "files.insertFinalNewline": true,
-  // all these to false because of eslint-prettier
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[javascriptreact]": {
-    "editor.formatOnSave": false
-  },
-  "[typescriptreact]": {
-    "editor.formatOnSave": false
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.3.5",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-prettier": "^3.4.0",
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-react": "^7.23.2",
         "eslint-plugin-react-hooks": "^4.2.0",
@@ -5916,27 +5915,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.0.0",
-        "prettier": ">=1.13.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -21814,15 +21792,6 @@
         "has": "^1.0.3",
         "jsx-ast-utils": "^3.1.0",
         "language-tags": "^1.0.5"
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.5",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",


### PR DESCRIPTION


**Describe your changes**

- disable eslint + prettier integration
- instead use prettier for all formatting

New wanted behavior:

```gherkin
Scenario: Vscode shows only real errors

Given I am using vscode
When I start typing new code
Then vscode only shows programming errors (lints)
And vscode does not show formatting errors
And vscode automatically fixes formatting errors on save
And I do not see lots of red squiggles
And I do not get confused by excessive squiggles
```

**Testing performed**
- ran prettier locally. Verified that it was formatting.
- ran eslint locally with errors

**Additional context**
Without this change the following happens:

```gherkin
Scenario: Vscode shows too many errors

Given I am using vscode
When I start typing new code
Then vscode shows a lot of errors (red squiggles)
And I get confused if I have a programming error.
```