### PR TITLE
build(lint): use pure prettier for formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "davidanson.vscode-markdownlint",
     "yzhang.markdown-all-in-one",
     "dbaeumer.vscode-eslint",
-    "stylelint.vscode-stylelint"
+    "stylelint.vscode-stylelint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/docs/architecture/decisions/0004-use-use-eslint-config-prettier-instead-of-eslint-plugin-prettier.md
+++ b/docs/architecture/decisions/0004-use-use-eslint-config-prettier-instead-of-eslint-plugin-prettier.md
@@ -1,0 +1,49 @@
+# 4. Use use eslint-config-prettier instead of eslint-plugin-prettier
+
+Date: 2021-05-17
+
+## Status
+
+Accepted
+
+## Context
+
+There are 2 ways to enable eslint+prettier integration:
+[eslint-pluging-prettier](https://www.npmjs.com/package/eslint-plugin-prettier)
+and
+[eslint-config-prettier](https://github.com/prettier/eslint-config-prettier).
+
+Originally, We were enforcing prettier through `eslint-plugin-pretter`. The
+problem is that vscode shows a lot of errors as you're typing, and this is an
+unnecessary distraction. These errors are all trivial formatting discrepancies.
+
+## Decision
+
+- We will use `eslint-config-prettier` to disable all `eslint` formatting rules.
+- We will use the `prettier` tools (cli, and vscode plugin) to enforce
+  formatting instead.
+
+## Consequences
+
+## What becomes easier?
+
+- Coding becomes easier because there are no distracting red indicators for
+  trivial formatting discrepancies.
+- Formatting non-typescript/non-javascript resources becomes easier because
+  `prettier` can format many other extensions. For example: `yaml`, `json`, and
+  `markdown`
+
+## What becomes harder?
+
+- The `vscode` setup becomes more difficult because developers will need to
+  configure many different vscode plugins to remain compliant.
+  - **mitigation**: provide the necessary vscode settings in the project
+    workspace.
+- The PR process becomes more difficult because developers will need to ensure
+  they format their code according to the standard prettier format, and now this
+  includes non-js/non-ts files.
+  - **mitigation**
+    - Provide `vscode` settings.
+    - Provide `npm.scripts` to format the workspace.
+- Setting up CI becomes more difficult because we will need an additional job to
+  enforce formatting.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint:fix": "eslint . --quiet --fix",
     "stylelint": "stylelint '**/*.tsx'",
     "stylelint:fix": "stylelint '**/*.tsx' --fix",
-    "prettier": "prettier --write .",
+    "prettier:write": "prettier --write .",
     "prettier:verify": "prettier --check .",
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "cross-env NODE_ENV=production node dist/server/index.js"


### PR DESCRIPTION
**Describe your changes**
- disable eslint + prettier integration
- instead use prettier for all formatting
- add prettier extension suggestion


**Testing performed**
- Ensure vscode autoformats on save
- Ensure vscode does not show error marks on format errors
- Ensure eslint remains to work
- Ensure `prettier:verify` and `prettier:write work`

**Additional context**
There are 2 ways to enable eslint+prettier integration: [eslint-pluging-prettier](https://www.npmjs.com/package/eslint-plugin-prettier) and [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier).

We were enforcing prettier through `eslint-plugin-pretter`, and the problem is that vscode shows a lot of errors as you're typing. These errors are all trivial formatting discrepancies. 

This PR switches to `eslint-config-prettier` and this removes the distracting formatting errors from vscode. 
