### PR TITLE
ci(github-actions): switch npm caching to recommended config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: npm-cache
         with:
-          path: '**/node_modules'
+          path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-}
       - run: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npm test
   eslint:
     runs-on: ubuntu-latest
@@ -33,12 +33,12 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: npm-cache
         with:
-          path: '**/node_modules'
+          path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-}
       - run: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npm run eslint
   prettier:
     runs-on: ubuntu-latest
@@ -48,12 +48,12 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: npm-cache
         with:
-          path: '**/node_modules'
+          path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npm run prettier:verify
   stylelint:
     runs-on: ubuntu-latest
@@ -63,12 +63,12 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: npm-cache
         with:
-          path: '**/node_modules'
+          path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node
       - run: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npm run stylelint
   build:
     runs-on: ubuntu-latest
@@ -78,10 +78,10 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: npm-cache
         with:
-          path: '**/node_modules'
+          path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node
       - run: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npm run build


### PR DESCRIPTION
**Describe your changes**
GitHub recommends caching `~/.npm` instead of `node_modules`
see:
https://github.com/actions/cache/blob/9ab95382c899bf0953a0c6c1374373fc40456ffe/examples.md#node---npm

**Testing performed**
- [x] jobs run
- [x] jobs successfully run on re-play
- [x] jobs run faster on -replay

**Additional context**
I was working on the project and noticed sometimes the ci jobs were breaking. I dug into it and found this was the problem.

I switched to using the recommended configuration.
https://github.com/actions/cache/blob/main/examples.md#node---npm