### PR TITLE
fix(prisma): make prisma and @prisma/client match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/darker-grotesque": "^4.5.2",
-        "@prisma/client": "^2.30.3",
+        "@prisma/client": "^3.13.0",
         "ajv": "^8.2.0",
         "apollo-server-core": "^3.0.1",
         "apollo-server-express": "^3.0.1",
@@ -99,7 +99,7 @@
         "jest-mock-extended": "^2.0.2-beta2",
         "postcss": "^8.4.8",
         "prettier": "^2.3.2",
-        "prisma": "^3.9.2",
+        "prisma": "^3.13.0",
         "react-dom": "^17.0.2",
         "serve": "^13.0.2",
         "storybook-addon-outline": "^1.4.2",
@@ -5161,15 +5161,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.30.3.tgz",
-      "integrity": "sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.13.0.tgz",
+      "integrity": "sha512-lnEA2tTyVbO5mS1ehmHJQKBDiKB8shaR6s3azwj3Azfi5XHIfnqmkolLCvUeFYnkDCNVzGXJpUgKwQt/UOOYVQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines-version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b"
       },
       "engines": {
-        "node": ">=12.2"
+        "node": ">=12.6"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -5181,16 +5181,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86.tgz",
-      "integrity": "sha512-LjRssaWu9w2SrXitofnutRIyURI7l0veQYIALz7uY4shygM9nMcK3omXcObRm7TAcw3Z+9ytfK1B+ySOsOesxQ==",
+      "version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b.tgz",
+      "integrity": "sha512-Ip9CcCeUocH61eXu4BUGpvl5KleQyhcUVLpWCv+0ZmDv44bFaDpREqjGHHdRupvPN/ugB6gTlD9b9ewdj02yVA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw=="
+      "version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b.tgz",
+      "integrity": "sha512-TGp9rvgJIKo8NgvAHSwOosbut9mTA7VC6/rpQI9gh+ySSRjdQFhbGyNUiOcQrlI9Ob2DWeO7y4HEnhdKxYiECg=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -28746,13 +28746,14 @@
       }
     },
     "node_modules/prisma": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.10.0.tgz",
-      "integrity": "sha512-dAld12vtwdz9Rz01nOjmnXe+vHana5PSog8t0XGgLemKsUVsaupYpr74AHaS3s78SaTS5s2HOghnJF+jn91ZrA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.13.0.tgz",
+      "integrity": "sha512-oO1auBnBtieGdiN+57IgsA9Vr7Sy4HkILi1KSaUG4mpKfEbnkTGnLOxAqjLed+K2nsG/GtE1tJBtB7JxN1a78Q==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
+        "@prisma/engines": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+        "ts-pattern": "^4.0.1"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -33773,6 +33774,12 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "node_modules/ts-pattern": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.2.tgz",
+      "integrity": "sha512-eHqR/7A6fcw05vCOfnL6RwgGJbVi9G/YHTdYdjYmElhDdJ1SMn7pWs+6+YuxygaFwQS/g+cIDlu+UD8IVpur1A==",
+      "devOptional": true
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
@@ -39669,23 +39676,23 @@
       "dev": true
     },
     "@prisma/client": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.30.3.tgz",
-      "integrity": "sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.13.0.tgz",
+      "integrity": "sha512-lnEA2tTyVbO5mS1ehmHJQKBDiKB8shaR6s3azwj3Azfi5XHIfnqmkolLCvUeFYnkDCNVzGXJpUgKwQt/UOOYVQ==",
       "requires": {
-        "@prisma/engines-version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines-version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b"
       }
     },
     "@prisma/engines": {
-      "version": "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86.tgz",
-      "integrity": "sha512-LjRssaWu9w2SrXitofnutRIyURI7l0veQYIALz7uY4shygM9nMcK3omXcObRm7TAcw3Z+9ytfK1B+ySOsOesxQ==",
+      "version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b.tgz",
+      "integrity": "sha512-Ip9CcCeUocH61eXu4BUGpvl5KleQyhcUVLpWCv+0ZmDv44bFaDpREqjGHHdRupvPN/ugB6gTlD9b9ewdj02yVA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw=="
+      "version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b.tgz",
+      "integrity": "sha512-TGp9rvgJIKo8NgvAHSwOosbut9mTA7VC6/rpQI9gh+ySSRjdQFhbGyNUiOcQrlI9Ob2DWeO7y4HEnhdKxYiECg=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -58211,12 +58218,13 @@
       "dev": true
     },
     "prisma": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.10.0.tgz",
-      "integrity": "sha512-dAld12vtwdz9Rz01nOjmnXe+vHana5PSog8t0XGgLemKsUVsaupYpr74AHaS3s78SaTS5s2HOghnJF+jn91ZrA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.13.0.tgz",
+      "integrity": "sha512-oO1auBnBtieGdiN+57IgsA9Vr7Sy4HkILi1KSaUG4mpKfEbnkTGnLOxAqjLed+K2nsG/GtE1tJBtB7JxN1a78Q==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
+        "@prisma/engines": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
+        "ts-pattern": "^4.0.1"
       }
     },
     "prismjs": {
@@ -62200,6 +62208,12 @@
           }
         }
       }
+    },
+    "ts-pattern": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.2.tgz",
+      "integrity": "sha512-eHqR/7A6fcw05vCOfnL6RwgGJbVi9G/YHTdYdjYmElhDdJ1SMn7pWs+6+YuxygaFwQS/g+cIDlu+UD8IVpur1A==",
+      "devOptional": true
     },
     "ts-pnp": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "jest-mock-extended": "^2.0.2-beta2",
     "postcss": "^8.4.8",
     "prettier": "^2.3.2",
-    "prisma": "^3.9.2",
+    "prisma": "^3.13.0",
     "react-dom": "^17.0.2",
     "serve": "^13.0.2",
     "storybook-addon-outline": "^1.4.2",
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@fontsource/darker-grotesque": "^4.5.2",
-    "@prisma/client": "^2.30.3",
+    "@prisma/client": "^3.13.0",
     "ajv": "^8.2.0",
     "apollo-server-core": "^3.0.1",
     "apollo-server-express": "^3.0.1",

--- a/src/server/log.ts
+++ b/src/server/log.ts
@@ -3,7 +3,12 @@ import { LOG_LEVEL as level, LOG_PRETTY as prettyPrint } from './environment'
 
 const log = pino({
   level,
-  prettyPrint,
+
+  ...(prettyPrint && {
+    transport: {
+      target: 'pino-pretty',
+    },
+  }),
   ...(prettyPrint && {
     timestamp: pino.stdTimeFunctions.isoTime,
   }),


### PR DESCRIPTION
Signed-off-by: vgarciavalen <info@vgarcia.dev>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Fix prisma warning when run `npx prisma generate`

```bash
warn Versions of prisma@3.10.0 and @prisma/client@2.30.3 don't match.
```

**Testing performed**
- [x] ran `npm run verify`
- [x] reset the db `npx prisma migrate dev reset`
  - [x] Signed in for the first time
  - [x] Sign out, then sign in again

**Additional context**
Fixed by:

```bash
npm install prisma@latest
npm install @prisma/client@latest
```
